### PR TITLE
s/no-focus-change/focus-capturing-application/g

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ const surfaceType = track.getSettings().displaySurface;
 if (surfaceType == "browser") {
   controller.setFocusBehavior("focus-captured-surface");
 } else if (surfaceType == "window") {
-  controller.setFocusBehavior("no-focus-change");
+  controller.setFocusBehavior("focus-capturing-application");
 }
 ```
 
@@ -67,7 +67,7 @@ const stream = await navigator.mediaDevices.getDisplayMedia({
 const [track] = stream.getVideoTracks();
 if (track.getSettings().displaySurface == "browser" &&
     track.getCaptureHandle().origin == "https://some.specific.url") {
-  controller.setFocusBehavior("no-focus-change");
+  controller.setFocusBehavior("focus-capturing-application");
 } else {
   controller.setFocusBehavior("focus-captured-surface");
 }


### PR DESCRIPTION
This PR uses the [new](https://github.com/w3c/mediacapture-screen-share/pull/270/) `"focus-capturing-application"` instead of `"no-focus-change"` in the README.md file.